### PR TITLE
add logging in the setup script and clean up pods

### DIFF
--- a/community_images/common/helpers.sh
+++ b/community_images/common/helpers.sh
@@ -5,7 +5,7 @@ set -e
 
 SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 # shellcheck disable=SC1091
-. "${SCRIPTPATH}"/retry_helper.sh
+. "${SCRIPTPATH}"/../../common/retry_helper.sh
 
 DOCKERHUB_REGISTRY="${DOCKERHUB_REGISTRY:-docker.io}"
 RAPIDFORT_ACCOUNT="${RAPIDFORT_ACCOUNT:-rapidfort}"

--- a/community_images/common/helpers.sh
+++ b/community_images/common/helpers.sh
@@ -3,6 +3,10 @@
 set -x
 set -e
 
+SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+# shellcheck disable=SC1091
+. "${SCRIPTPATH}"/retry_helper.sh
+
 DOCKERHUB_REGISTRY="${DOCKERHUB_REGISTRY:-docker.io}"
 RAPIDFORT_ACCOUNT="${RAPIDFORT_ACCOUNT:-rapidfort}"
 SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
@@ -269,47 +273,6 @@ function build_images()
         fi
         build_image "${INPUT_REGISTRY}" "${INPUT_ACCOUNT}" "${REPOSITORY}" "${tag}" "${OUTPUT_REPOSITORY}" test "${PUBLISH_IMAGE}" "${IS_LATEST_TAG}"
     done
-}
-
-# Retries a command a with backoff.
-#
-# The retry count is given by ATTEMPTS (default 10), the
-# initial backoff timeout is given by TIMEOUT in seconds
-# (default 5.)
-#
-# Successive backoffs double the timeout.
-#
-# Beware of set -e killing your whole script!
-function with_backoff {
-  local max_attempts="${ATTEMPTS-9}"
-  local timeout="${TIMEOUT-5}"
-  local attempt=0
-  local exitCode=0
-
-  while [[ "$attempt" < "$max_attempts" ]]
-  do
-    set +e
-    "$@"
-    exitCode="$?"
-    set -e
-
-    if [[ "$exitCode" == 0 ]]
-    then
-      break
-    fi
-
-    echo "Failure! Retrying in $timeout.." 1>&2
-    sleep "$timeout"
-    attempt=$(( attempt + 1 ))
-    timeout=$(( timeout * 2 ))
-  done
-
-  if [[ "$exitCode" != 0 ]]
-  then
-    echo "You've failed me for the last time! ($*)" 1>&2
-  fi
-
-  return "$exitCode"
 }
 
 function cleanup_certs()

--- a/community_images/common/retry_helper.sh
+++ b/community_images/common/retry_helper.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -x
+set -e
+
+# Retries a command a with backoff.
+#
+# The retry count is given by ATTEMPTS (default 10), the
+# initial backoff timeout is given by TIMEOUT in seconds
+# (default 5.)
+#
+# Successive backoffs double the timeout.
+#
+# Beware of set -e killing your whole script!
+function with_backoff {
+  local max_attempts="${ATTEMPTS-9}"
+  local timeout="${TIMEOUT-5}"
+  local attempt=0
+  local exitCode=0
+
+  while [[ "$attempt" < "$max_attempts" ]]
+  do
+    set +e
+    "$@"
+    exitCode="$?"
+    set -e
+
+    if [[ "$exitCode" == 0 ]]
+    then
+      break
+    fi
+
+    echo "Failure! Retrying in $timeout.." 1>&2
+    sleep "$timeout"
+    attempt=$(( attempt + 1 ))
+    timeout=$(( timeout * 2 ))
+  done
+
+  if [[ "$exitCode" != 0 ]]
+  then
+    echo "You've failed me for the last time! ($*)" 1>&2
+  fi
+
+  return "$exitCode"
+}

--- a/community_images/nats/bitnami/coverage.sh
+++ b/community_images/nats/bitnami/coverage.sh
@@ -10,25 +10,27 @@ function test_nats() {
    local HELM_RELEASE=$2
 
    NATS_USER=$(kubectl get secret --namespace "${NAMESPACE}" "${HELM_RELEASE}" -o jsonpath='{.data.*}' | base64 -d | grep -m 1 user | awk '{print $2}' | tr -d '"')
-    NATS_PASS=$(kubectl get secret --namespace "${NAMESPACE}" "${HELM_RELEASE}" -o jsonpath='{.data.*}' | base64 -d | grep -m 1 password | awk '{print $2}' | tr -d '"')
-    echo -e "Client credentials:\n\tUser: $NATS_USER\n\tPassword: $NATS_PASS"
+   NATS_PASS=$(kubectl get secret --namespace "${NAMESPACE}" "${HELM_RELEASE}" -o jsonpath='{.data.*}' | base64 -d | grep -m 1 password | awk '{print $2}' | tr -d '"')
+   echo -e "Client credentials:\n\tUser: $NATS_USER\n\tPassword: $NATS_PASS"
 
-    kubectl run nats-release-client --restart='Never' --env="NATS_USER=$NATS_USER" --env="NATS_PASS=$NATS_PASS" --image docker.io/bitnami/golang --namespace "${NAMESPACE}" --command -- sleep infinity
+   # clean up the pod with name nats-release-client first if present already
+   kubectl delete pod nats-release-client --namespace "${NAMESPACE}" --ignore-not-found=true
+   kubectl run nats-release-client --restart='Never' --env="NATS_USER=$NATS_USER" --env="NATS_PASS=$NATS_PASS" --image docker.io/bitnami/golang --namespace "${NAMESPACE}" --command -- sleep infinity
     # wait for nats client to come up
-    kubectl wait pods nats-release-client -n "${NAMESPACE}" --for=condition=ready --timeout=10m
-    echo "#!/bin/bash
-    GO111MODULE=off go get github.com/nats-io/nats.go
-    cd \"\$GOPATH\"/src/github.com/nats-io/nats.go/examples/nats-pub && go install && cd || exit
-    cd \"\$GOPATH\"/src/github.com/nats-io/nats.go/examples/nats-echo && go install && cd || exit
-    nats-echo -s nats://$NATS_USER:$NATS_PASS@${HELM_RELEASE}.${NAMESPACE}.svc.cluster.local:4222 SomeSubject &
-    nats-pub -s nats://$NATS_USER:$NATS_PASS@${HELM_RELEASE}.${NAMESPACE}.svc.cluster.local:4222 -reply Hi SomeSubject 'Hi everyone'" > "$SCRIPTPATH"/commands.sh
+   kubectl wait pods nats-release-client -n "${NAMESPACE}" --for=condition=ready --timeout=10m
+   echo "#!/bin/bash
+   GO111MODULE=off go get github.com/nats-io/nats.go
+   cd \"\$GOPATH\"/src/github.com/nats-io/nats.go/examples/nats-pub && go install && cd || exit
+   cd \"\$GOPATH\"/src/github.com/nats-io/nats.go/examples/nats-echo && go install && cd || exit
+   nats-echo -s nats://$NATS_USER:$NATS_PASS@${HELM_RELEASE}.${NAMESPACE}.svc.cluster.local:4222 SomeSubject &
+   nats-pub -s nats://$NATS_USER:$NATS_PASS@${HELM_RELEASE}.${NAMESPACE}.svc.cluster.local:4222 -reply Hi SomeSubject 'Hi everyone'" > "$SCRIPTPATH"/commands.sh
 
-    chmod +x "$SCRIPTPATH"/commands.sh
-    POD_NAME="nats-release-client"
-    kubectl -n "${NAMESPACE}" cp "${SCRIPTPATH}"/commands.sh "${POD_NAME}":/tmp/common_commands.sh
+   chmod +x "$SCRIPTPATH"/commands.sh
+   POD_NAME="nats-release-client"
+   kubectl -n "${NAMESPACE}" cp "${SCRIPTPATH}"/commands.sh "${POD_NAME}":/tmp/common_commands.sh
 
-    kubectl -n "${NAMESPACE}" exec -i "${POD_NAME}" -- bash -c "/tmp/common_commands.sh"
+   kubectl -n "${NAMESPACE}" exec -i "${POD_NAME}" -- bash -c "/tmp/common_commands.sh"
 
-    # delete the generated commands.sh
-    rm "$SCRIPTPATH"/commands.sh
+   # delete the generated commands.sh
+   rm "$SCRIPTPATH"/commands.sh
 }

--- a/community_images/wordpress/bitnami/conftest.py
+++ b/community_images/wordpress/bitnami/conftest.py
@@ -4,15 +4,15 @@ import pytest #pylint: disable=import-error
 
 def pytest_addoption(parser):
     """The function to add options"""
-    parser.addoption("--ip_address", action="store", help="ip address of wordpress")
+    parser.addoption("--wordpress_server", action="store", help="wordpress server")
     parser.addoption("--port", action="store", help="port for wordpress container")
 
 @pytest.fixture
 def params(request):
     """the params"""
     config_params = {}
-    config_params['ip_address'] = request.config.getoption('--ip_address')
+    config_params['wordpress_server'] = request.config.getoption('--wordpress_server')
     config_params['port'] = request.config.getoption('--port')
-    if config_params['ip_address'] is None or config_params['port'] is None:
+    if config_params['wordpress_server'] is None or config_params['port'] is None:
         pytest.skip()
     return config_params

--- a/community_images/wordpress/bitnami/functional_test.sh
+++ b/community_images/wordpress/bitnami/functional_test.sh
@@ -28,7 +28,9 @@ k8s_test()
     # wait for deployments
     kubectl wait deployments "${HELM_RELEASE}" -n "${NAMESPACE}" --for=condition=Available=true --timeout=10m
 
-    test_selenium "${NAMESPACE}"
+    WORDPRESS_SERVER="${HELM_RELEASE}"."${NAMESPACE}".svc.cluster.local
+
+    test_selenium "${NAMESPACE}" "${WORDPRESS_SERVER}"
 
     # log pods
     kubectl -n "${NAMESPACE}" get pods

--- a/community_images/wordpress/bitnami/run.sh
+++ b/community_images/wordpress/bitnami/run.sh
@@ -50,7 +50,9 @@ test()
     # run command on cluster
     kubectl -n "${NAMESPACE}" exec -i "${POD_NAME}" -- /bin/bash -c "/tmp/common_commands.sh"
 
-    test_selenium "${NAMESPACE}"
+    WORDPRESS_SERVER="${HELM_RELEASE}"."${NAMESPACE}".svc.cluster.local
+
+    test_selenium "${NAMESPACE}" "${WORDPRESS_SERVER}"
 
     # bring down helm install
     helm delete "${HELM_RELEASE}" --namespace "${NAMESPACE}"

--- a/community_images/wordpress/bitnami/selenium_helper.sh
+++ b/community_images/wordpress/bitnami/selenium_helper.sh
@@ -7,6 +7,7 @@ SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
 function test_selenium() {
     local NAMESPACE=$1
+    local WORDPRESS_SERVER=$2
 
     # get the ip address of wordpress service
     WORDPRESS_IP=$(kubectl get nodes --namespace "${NAMESPACE}" -o jsonpath="{.items[0].status.addresses[0].address}")
@@ -15,6 +16,9 @@ function test_selenium() {
 
     echo "wordpress IP is $WORDPRESS_IP"
     echo "wordpress port is $WORDPRESS_PORT"
+
+    WORDPRESS_IP=$WORDPRESS_SERVER
+    WORDPRESS_PORT='80'
 
     CHROME_POD="python-chromedriver"
     # delete the directory if present already

--- a/community_images/wordpress/bitnami/selenium_helper.sh
+++ b/community_images/wordpress/bitnami/selenium_helper.sh
@@ -19,6 +19,9 @@ function test_selenium() {
     CHROME_POD="python-chromedriver"
     # delete the directory if present already
     rm -rf "${SCRIPTPATH}"/docker-python-chromedriver
+    # delete the pod if present already, this sometimes happens if the cleanup didn't happen properly and is transient
+    kubectl delete pod "${CHROME_POD}" --namespace "${NAMESPACE}" --ignore-not-found=true
+    # clone the docker python chromedriver repo
     git clone https://github.com/joyzoursky/docker-python-chromedriver.git "${SCRIPTPATH}"/docker-python-chromedriver
     # cd docker-python-chromedriver
     kubectl run "${CHROME_POD}" --restart='Never' --image joyzoursky/"${CHROME_POD}":latest --namespace "${NAMESPACE}" --command -- sleep infinity

--- a/community_images/wordpress/bitnami/selenium_helper.sh
+++ b/community_images/wordpress/bitnami/selenium_helper.sh
@@ -42,7 +42,7 @@ function test_selenium() {
     kubectl -n "${NAMESPACE}" cp "${SCRIPTPATH}"/wordpress_selenium_test.py "${CHROME_POD}":/tmp/wordpress_selenium_test.py
     chmod +x "$SCRIPTPATH"/commands.sh
     kubectl -n "${NAMESPACE}" cp "${SCRIPTPATH}"/commands.sh "${CHROME_POD}":/tmp/common_commands.sh
-    kubectl -name "${NAMESPACE}" cp "${SCRIPTPATH}"/../../common/helpers.sh "${CHROME_POD}":/tmp/helpers.sh
+    kubectl -n "${NAMESPACE}" cp "${SCRIPTPATH}"/../../common/retry_helper.sh "${CHROME_POD}":/tmp/helpers.sh
 
     kubectl -n "${NAMESPACE}" exec -i "${CHROME_POD}" -- bash -c "/tmp/common_commands.sh"
     # delete the generated commands.sh

--- a/community_images/wordpress/bitnami/selenium_helper.sh
+++ b/community_images/wordpress/bitnami/selenium_helper.sh
@@ -37,6 +37,9 @@ function test_selenium() {
     cd /usr/workspace
     pip install pytest
     pip install selenium
+    apt update
+    apt -y install dnsutils
+    nslookup $WORDPRESS_IP
     pytest -s /tmp/wordpress_selenium_test.py --ip_address $WORDPRESS_IP --port $WORDPRESS_PORT" > "$SCRIPTPATH"/commands.sh
     kubectl -n "${NAMESPACE}" cp "${SCRIPTPATH}"/conftest.py "${CHROME_POD}":/tmp/conftest.py
     kubectl -n "${NAMESPACE}" cp "${SCRIPTPATH}"/wordpress_selenium_test.py "${CHROME_POD}":/tmp/wordpress_selenium_test.py

--- a/community_images/wordpress/bitnami/wordpress_selenium_test.py
+++ b/community_images/wordpress/bitnami/wordpress_selenium_test.py
@@ -26,6 +26,7 @@ class TestWordpresstest1():
         chrome_options.add_argument("--disable-gpu")
         chrome_options.add_argument("--no-sandbox")
         self.driver = webdriver.Chrome(options=chrome_options)  # pylint: disable=attribute-defined-outside-init
+        self.driver.implicitly_wait(10)
 
     def teardown_method(self, method):  # pylint: disable=unused-argument
         """teardown method."""

--- a/community_images/wordpress/bitnami/wordpress_selenium_test.py
+++ b/community_images/wordpress/bitnami/wordpress_selenium_test.py
@@ -37,7 +37,7 @@ class TestWordpresstest1():
         # Test name: wordpress-test-1
         # Step # | name | target | value
         # 1 | open | / |
-        self.driver.get("http://{}:{}/".format(params["ip_address"], params["port"]))  # pylint: disable=consider-using-f-string
+        self.driver.get("http://{}:{}/".format(params["wordpress_server"], params["port"]))  # pylint: disable=consider-using-f-string
         # 2 | setWindowSize | 1095x688 |
         self.driver.set_window_size(1095, 688)
         # 3 | click | linkText=Hello world! |
@@ -63,7 +63,7 @@ class TestWordpresstest1():
         """Test name: simplelogin."""
         # Step # | name | target | value
         # 1 | open | /wp-login.php |
-        self.driver.get("http://{}:{}/users.php".format(params["ip_address"], params["port"]))  # pylint: disable=consider-using-f-string
+        self.driver.get("http://{}:{}/users.php".format(params["wordpress_server"], params["port"]))  # pylint: disable=consider-using-f-string
         # 2 | setWindowSize | 1200x828 |
         self.driver.set_window_size(1200, 828)
 
@@ -71,7 +71,7 @@ class TestWordpresstest1():
     #     """Test name: simplelogin."""
     #     # Step # | name | target | value
     #     # 1 | open | /wp-login.php |
-    #     self.driver.get("http://{}:{}/wp-admin/user-new.php".format(params["ip_address"], params["port"]))  # pylint: disable=consider-using-f-string disable=line-too-long
+    #     self.driver.get("http://{}:{}/wp-admin/user-new.php".format(params["wordpress_server"], params["port"]))  # pylint: disable=consider-using-f-string disable=line-too-long
     #     # 2 | setWindowSize | 1200x828 |
     #     self.driver.set_window_size(1200, 828)
     #     self.driver.find_element(By.ID, "user_login").send_keys("user3")
@@ -98,7 +98,7 @@ class TestWordpresstest1():
     #     """Test name: simplelogin."""
     #     # Step # | name | target | value
     #     # 1 | open | /wp-login.php |
-    #     self.driver.get("http://{}:{}/wp-admin/options-general.php".format(params["ip_address"], params["port"]))  # pylint: disable=consider-using-f-string disable=line-too-long
+    #     self.driver.get("http://{}:{}/wp-admin/options-general.php".format(params["wordpress_server"], params["port"]))  # pylint: disable=consider-using-f-string disable=line-too-long
     #     # 2 | setWindowSize | 1200x828 |
     #     self.driver.set_window_size(1200, 828)
     #     # 21 | click | id=start_of_week |
@@ -113,7 +113,7 @@ class TestWordpresstest1():
         """Test name: simplelogin."""
         # Step # | name | target | value
         # 1 | open | /wp-login.php |
-        self.driver.get("http://{}:{}/wp-login.php".format(params["ip_address"], params["port"]))  # pylint: disable=consider-using-f-string
+        self.driver.get("http://{}:{}/wp-login.php".format(params["wordpress_server"], params["port"]))  # pylint: disable=consider-using-f-string
         # 2 | setWindowSize | 1200x828 |
         self.driver.set_window_size(1200, 828)
         # 3 | type | id=user_login | user

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -e
+set -x
+
 EPH_SETUP=no
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -60,6 +63,7 @@ sudo apt-get install jq parallel -y
 # install docker-compose latest
 DC_VERSION=$(curl --silent https://api.github.com/repos/docker/compose/releases/latest | grep -Po '"tag_name": "\K.*\d')
 DC_DESTINATION=/usr/local/bin/docker-compose
+echo "Downloding  https://github.com/docker/compose/releases/download/${DC_VERSION}/docker-compose-$(uname -s)-$(uname -m)"
 sudo curl -L https://github.com/docker/compose/releases/download/"${DC_VERSION}"/docker-compose-"$(uname -s)"-"$(uname -m)" -o "$DC_DESTINATION"
 sudo chmod 755 $DC_DESTINATION
 


### PR DESCRIPTION
this diff adds logging in the setup script to figure out the version of
docker-compose that we try to download in the github actions. There were
couple of intermittent issues in nats and wordpress image where the
coverage script pods start up failed because the pods were already
present since clean up didn't happen properly. The coverage script tries
to clean up the pods if present already before starting fresh ones.

Test Plan:
N/A

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Rapidfort might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Added to the `README.md` using [readme-generator](https://github.com/rapidfort/community-images/readme-generator)
