### PR TITLE
Fix the docker compose env file issue with logs

### DIFF
--- a/community_images/common/orchestrator/docker_compose_setup.py
+++ b/community_images/common/orchestrator/docker_compose_setup.py
@@ -75,6 +75,7 @@ class DockerComposeSetup:
 
         # dump logs
         cmd = "docker-compose"
+        cmd += f" --env-file {self.temp_env_file}"
         cmd += f" -f {self.docker_file} -p {self.namespace_name}"
         cmd += " logs"
         logging.info(f"cmd: {cmd}")


### PR DESCRIPTION
The logs command for docker-compose was not using the env-file option which was causing it to fail. since we are not using the default .env file, this env-file should be explicitly passed with all docker-compose commands.