### PR TITLE
Added coverage for missing binaries

### DIFF
--- a/community_images/common/tests/mysql_coverage.sh
+++ b/community_images/common/tests/mysql_coverage.sh
@@ -11,6 +11,11 @@ mysqladmin --version
 mysqlcheck --version
 mysqldump --version
 mysqlimport --version
-# mysqlpump --version # not present on mariadb
+
+# exclude mariadb
+mariadb --version || (	mysqlpump --version && \
+						mysql_ssl_rsa_setup --version && \
+						mysqlsh --version )
+
 mysqlshow --version
 # mysqlslap --version # doesnt work on mariadb due to char set issue


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Rapidfort might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Added lines to cover `mysqlpump`,  `mysql_ssl_rsa_setup` and `mysqlsh` in all MySQL images, except MariaDB(these binaries are not available in original image).

### Benefits

<!-- What benefits will be realized by the code change? -->
Many utilities covered in original MySQL images(considering MariaDB images also) will also get included inside Rapidfort's hardened images.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #249 
  - fixes #250 
  - fixes #252 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Added to the `README.md` using [readme-generator](https://github.com/rapidfort/community-images/readme-generator)
