### PR TITLE
[Good to merge] mysqlbinlog command added to coverage

### DIFF
--- a/community_images/common/tests/mysql_coverage.sh
+++ b/community_images/common/tests/mysql_coverage.sh
@@ -17,4 +17,4 @@ mysqlshow --version
 mysqld_safe --help || mysqld --version
 # mysqld_safe is deisgned such that it'll always give exit code status as 1
 # mysqld_safe --syslog
-
+mysqlbinlog --no-defaults --version


### PR DESCRIPTION
### Description of the change
The mysqlbinlog command which is core functionality and does not cause any vulnerabilities was missing the coverage of the hardened images of bitnami/MySQL.
To resolve this error I needed to add the command in the mysql_coverage.sh, a file that was being used by other images including bitnami/MySQL, MySQL original, bitnami/MariaDB, and MariaDB original. Adding the command allows users to access the mysqlbinlog for all these images. 
This command allows users to read and analyze MySQL binary log files containing logs of database changes. 

### Benefits
This command allows users to read and analyze MySQL binary log files containing logs of database changes. 
This command can help in data recovery as well as debugging.

### Possible drawbacks

To successfully execute it for the bitnami version of the images, I needed to tag it with --no-defaults, which may result in missing some default settings, though I reviewed the behaviour of the command to ensure that it is functioning as expected.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #258 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Added to the `README.md` using [readme-generator](https://github.com/rapidfort/community-images/readme-generator)
