### PR TITLE
Updated bitnami tag

### DIFF
--- a/community_images/fluentd/bitnami/image.yml
+++ b/community_images/fluentd/bitnami/image.yml
@@ -23,7 +23,7 @@ input_registry:
   account: bitnami
 repo_sets:
   - fluentd:
-      input_base_tag: "1.15.3-debian-11-r"
+      input_base_tag: "1.16.1-debian-11-r"
 runtimes:
   - type: k8s
     script: k8s_coverage.sh


### PR DESCRIPTION
- Command `gem install fluent-plugin-elasticsearch` had started failing on the container since some new update on gem package probably. Re-running and re-hardening the image would fix it.