### PR TITLE
Updated tags for Redis 7 Support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "git-blame.gitWebUrl": ""
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "git-blame.gitWebUrl": ""
+}

--- a/community_images/redis/bitnami/image.yml
+++ b/community_images/redis/bitnami/image.yml
@@ -23,9 +23,11 @@ input_registry:
   account: bitnami
 repo_sets:
   - redis:
-      input_base_tag: "7.0.11-debian-11-r"
+      input_base_tag: "7.2.0-debian-11-r"
   - redis:
-      input_base_tag: "6.2.12-debian-11-r"
+      input_base_tag: "7.0.12-debian-11-r"
+  - redis:
+      input_base_tag: "6.2.13-debian-11-r"
 runtimes:
   - type: k8s
     script: k8s_coverage.sh

--- a/community_images/redis/ironbank/image.yml
+++ b/community_images/redis/ironbank/image.yml
@@ -22,7 +22,7 @@ input_registry:
   account: ironbank
 repo_sets:
   - opensource/redis/redis6:
-      input_base_tag: "6."
+      input_base_tag: "6.2."
       output_repo: redis6-ib
 runtimes:
   - type: docker_compose

--- a/community_images/redis/official/dc_coverage.sh
+++ b/community_images/redis/official/dc_coverage.sh
@@ -13,7 +13,7 @@ NAMESPACE=$(jq -r '.namespace_name' < "$JSON_PARAMS")
 CONTAINER_NAME="${NAMESPACE}"-redis-primary-1
 
 # run redis tests
-docker exec -i "${CONTAINER_NAME}" bash -c "cat /tmp/test.redis | redis-cli"
+docker exec -i "${CONTAINER_NAME}" "cat /tmp/test.redis | redis-cli"
 
 # run redis coverage
-docker exec -i "${CONTAINER_NAME}" bash -c "/tmp/redis_coverage.sh"
+docker exec -i "${CONTAINER_NAME}" "/tmp/redis_coverage.sh"

--- a/community_images/redis/official/dc_coverage.sh
+++ b/community_images/redis/official/dc_coverage.sh
@@ -13,7 +13,7 @@ NAMESPACE=$(jq -r '.namespace_name' < "$JSON_PARAMS")
 CONTAINER_NAME="${NAMESPACE}"-redis-primary-1
 
 # run redis tests
-docker exec -i "${CONTAINER_NAME}" "cat /tmp/test.redis | redis-cli"
+(docker exec -i "${CONTAINER_NAME}" bash -c "cat ../tmp/test.redis | redis-cli") || (docker exec -i "${CONTAINER_NAME}" sh -c "cat ../tmp/test.redis | redis-cli") 
 
 # run redis coverage
-docker exec -i "${CONTAINER_NAME}" "/tmp/redis_coverage.sh"
+(docker exec -i "${CONTAINER_NAME}" sh ../tmp/redis_coverage.sh) || (docker exec -i "${CONTAINER_NAME}" bash -c "../tmp/redis_coverage.sh")

--- a/community_images/redis/official/docker.env.temp
+++ b/community_images/redis/official/docker.env.temp
@@ -1,0 +1,2 @@
+REDIS_IMAGE_REPOSITORY=rapidfort/redis-official
+REDIS_IMAGE_TAG=6.0.20-alpine3.18

--- a/community_images/redis/official/image.yml
+++ b/community_images/redis/official/image.yml
@@ -16,10 +16,10 @@ what_is_text: |
 disclaimer: |
   Disclaimer: Redis is a registered trademark of Redis Labs Ltd. Any rights therein are reserved to Redis Labs Ltd. Any use by RapidFort is for referential purposes only and does not indicate any sponsorship, endorsement, or affiliation between Redis Labs Ltd.
 docker_links:
-  -	"[`7.2.0`, `7.2`, `7`, `latest`, `7.2.0-bookworm`, `7.2-bookworm`, `7-bookworm`, `bookworm`](https://github.com/docker-library/redis/blob/9b538c33746872dcd1e8c809cbde9f21ac2ec3ac/7.2/Dockerfile)"
-  -	"[`7.2.0-alpine`, `7.2-alpine`, `7-alpine`, `alpine`, `7.2.0-alpine3.18`, `7.2-alpine3.18`, `7-alpine3.18`, `alpine3.18`](https://github.com/docker-library/redis/blob/9b538c33746872dcd1e8c809cbde9f21ac2ec3ac/7.2/alpine/Dockerfile)"
+  - "[`7.2.0`, `7.2`, `7`, `latest`, `7.2.0-bookworm`, `7.2-bookworm`, `7-bookworm`, `bookworm`](https://github.com/docker-library/redis/blob/9b538c33746872dcd1e8c809cbde9f21ac2ec3ac/7.2/Dockerfile)"
+  - "[`7.2.0-alpine`, `7.2-alpine`, `7-alpine`, `alpine`, `7.2.0-alpine3.18`, `7.2-alpine3.18`, `7-alpine3.18`, `alpine3.18`](https://github.com/docker-library/redis/blob/9b538c33746872dcd1e8c809cbde9f21ac2ec3ac/7.2/alpine/Dockerfile)"
   -	"[`7.0.12`, `7.0`, `7.0.12-bookworm`, `7.0-bookworm`](https://github.com/docker-library/redis/blob/5c8459f1bd20b7b7f92325f83898636f3c8db95f/7.0/Dockerfile)"
-  -	"[`7.0.12-alpine`, `7.0-alpine`, `7.0.12-alpine3.18`, `7.0-alpine3.18`](https://github.com/docker-library/redis/blob/5c8459f1bd20b7b7f92325f83898636f3c8db95f/7.0/alpine/Dockerfile)"
+  -	"[`7.0.12-alpine`,  7.0-alpine`, `7.0.12-alpine3.18`, `7.0-alpine3.18`](https://github.com/docker-library/redis/blob/5c8459f1bd20b7b7f92325f83898636f3c8db95f/7.0/alpine/Dockerfile)"
   -	"[`6.2.13`, `6.2`, `6`, `6.2.13-bookworm`, `6.2-bookworm`, `6-bookworm`](https://github.com/docker-library/redis/blob/f2da8752a05b783eb805b67ad7a56a997a0fe91f/6.2/Dockerfile)"
   -	"[`6.2.13-alpine`, `6.2-alpine`, `6-alpine`, `6.2.13-alpine3.18`, `6.2-alpine3.18`, `6-alpine3.18`](https://github.com/docker-library/redis/blob/f2da8752a05b783eb805b67ad7a56a997a0fe91f/6.2/alpine/Dockerfile)"
   -	"[`6.0.20`, `6.0`, `6.0.20-bookworm`, `6.0-bookworm`](https://github.com/docker-library/redis/blob/873a7cac27da5a275d0c1e0c7d41724ae2701071/6.0/Dockerfile)"

--- a/community_images/redis/official/image.yml
+++ b/community_images/redis/official/image.yml
@@ -42,7 +42,7 @@ repo_sets:
       output_repo: redis-official
   - redis:
       input_base_tag: "7.0.*-alpine"
-      output_repo: redis-officia
+      output_repo: redis-official
   - redis:
       input_base_tag: "7.0.*-bookworm"
       output_repo: redis-official

--- a/community_images/redis/official/image.yml
+++ b/community_images/redis/official/image.yml
@@ -18,12 +18,12 @@ disclaimer: |
 docker_links:
   - "[`7.2.0`, `7.2`, `7`, `latest`, `7.2.0-bookworm`, `7.2-bookworm`, `7-bookworm`, `bookworm`](https://github.com/docker-library/redis/blob/9b538c33746872dcd1e8c809cbde9f21ac2ec3ac/7.2/Dockerfile)"
   - "[`7.2.0-alpine`, `7.2-alpine`, `7-alpine`, `alpine`, `7.2.0-alpine3.18`, `7.2-alpine3.18`, `7-alpine3.18`, `alpine3.18`](https://github.com/docker-library/redis/blob/9b538c33746872dcd1e8c809cbde9f21ac2ec3ac/7.2/alpine/Dockerfile)"
-  -	"[`7.0.12`, `7.0`, `7.0.12-bookworm`, `7.0-bookworm`](https://github.com/docker-library/redis/blob/5c8459f1bd20b7b7f92325f83898636f3c8db95f/7.0/Dockerfile)"
-  -	"[`7.0.12-alpine`,  7.0-alpine`, `7.0.12-alpine3.18`, `7.0-alpine3.18`](https://github.com/docker-library/redis/blob/5c8459f1bd20b7b7f92325f83898636f3c8db95f/7.0/alpine/Dockerfile)"
-  -	"[`6.2.13`, `6.2`, `6`, `6.2.13-bookworm`, `6.2-bookworm`, `6-bookworm`](https://github.com/docker-library/redis/blob/f2da8752a05b783eb805b67ad7a56a997a0fe91f/6.2/Dockerfile)"
-  -	"[`6.2.13-alpine`, `6.2-alpine`, `6-alpine`, `6.2.13-alpine3.18`, `6.2-alpine3.18`, `6-alpine3.18`](https://github.com/docker-library/redis/blob/f2da8752a05b783eb805b67ad7a56a997a0fe91f/6.2/alpine/Dockerfile)"
-  -	"[`6.0.20`, `6.0`, `6.0.20-bookworm`, `6.0-bookworm`](https://github.com/docker-library/redis/blob/873a7cac27da5a275d0c1e0c7d41724ae2701071/6.0/Dockerfile)"
-  -	"[`6.0.20-alpine`, `6.0-alpine`, `6.0.20-alpine3.18`, `6.0-alpine3.18`](https://github.com/docker-library/redis/blob/873a7cac27da5a275d0c1e0c7d41724ae2701071/6.0/alpine/Dockerfile)"
+  - "[`7.0.12`, `7.0`, `7.0.12-bookworm`, `7.0-bookworm`](https://github.com/docker-library/redis/blob/5c8459f1bd20b7b7f92325f83898636f3c8db95f/7.0/Dockerfile)"
+  - "[`7.0.12-alpine`,  7.0-alpine`, `7.0.12-alpine3.18`, `7.0-alpine3.18`](https://github.com/docker-library/redis/blob/5c8459f1bd20b7b7f92325f83898636f3c8db95f/7.0/alpine/Dockerfile)"
+  - "[`6.2.13`, `6.2`, `6`, `6.2.13-bookworm`, `6.2-bookworm`, `6-bookworm`](https://github.com/docker-library/redis/blob/f2da8752a05b783eb805b67ad7a56a997a0fe91f/6.2/Dockerfile)"
+  - "[`6.2.13-alpine`, `6.2-alpine`, `6-alpine`, `6.2.13-alpine3.18`, `6.2-alpine3.18`, `6-alpine3.18`](https://github.com/docker-library/redis/blob/f2da8752a05b783eb805b67ad7a56a997a0fe91f/6.2/alpine/Dockerfile)"
+  - "[`6.0.20`, `6.0`, `6.0.20-bookworm`, `6.0-bookworm`](https://github.com/docker-library/redis/blob/873a7cac27da5a275d0c1e0c7d41724ae2701071/6.0/Dockerfile)"
+  - "[`6.0.20-alpine`, `6.0-alpine`, `6.0.20-alpine3.18`, `6.0-alpine3.18`](https://github.com/docker-library/redis/blob/873a7cac27da5a275d0c1e0c7d41724ae2701071/6.0/alpine/Dockerfile)"
 input_registry:
   registry: docker.io
   account: library

--- a/community_images/redis/official/image.yml
+++ b/community_images/redis/official/image.yml
@@ -10,7 +10,7 @@ image_workflow_name: redis_official
 github_location: redis/official
 report_url: https://frontrow.rapidfort.com/app/community/imageinfo/docker.io%2Flibrary%2Fredis
 usage_instructions: |
-  $ docker run -it --rm -p6379:6379 rapidfort/redis-official:latest
+  $ docker run -it --rm -p 6379:6379 rapidfort/redis-official:latest
 what_is_text: |
   Redis™ is an open-source, networked, in-memory, key-value data store with optional durability. It is written in ANSI C. The development of Redis is sponsored by Redis Labs today; before that, it was sponsored by Pivotal and VMware. According to the monthly ranking by DB-Engines.com, Redis is the most popular key-value store. The name Redis means REmote DIctionary Server.
 disclaimer: |

--- a/community_images/redis/official/image.yml
+++ b/community_images/redis/official/image.yml
@@ -16,17 +16,41 @@ what_is_text: |
 disclaimer: |
   Disclaimer: Redis is a registered trademark of Redis Labs Ltd. Any rights therein are reserved to Redis Labs Ltd. Any use by RapidFort is for referential purposes only and does not indicate any sponsorship, endorsement, or affiliation between Redis Labs Ltd.
 docker_links:
-  - "[`7.0-bullseye`, `7-bullseye` (Dockerfile)](https://github.com/docker-library/redis/blob/master/7.0/Dockerfile)"
-  - "[`6.2-bullseye`, `6-bullseye` (Dockerfile)](https://github.com/docker-library/redis/blob/master/6.2/Dockerfile)"
+  -	"[`7.2.0`, `7.2`, `7`, `latest`, `7.2.0-bookworm`, `7.2-bookworm`, `7-bookworm`, `bookworm`](https://github.com/docker-library/redis/blob/9b538c33746872dcd1e8c809cbde9f21ac2ec3ac/7.2/Dockerfile)"
+  -	"[`7.2.0-alpine`, `7.2-alpine`, `7-alpine`, `alpine`, `7.2.0-alpine3.18`, `7.2-alpine3.18`, `7-alpine3.18`, `alpine3.18`](https://github.com/docker-library/redis/blob/9b538c33746872dcd1e8c809cbde9f21ac2ec3ac/7.2/alpine/Dockerfile)"
+  -	"[`7.0.12`, `7.0`, `7.0.12-bookworm`, `7.0-bookworm`](https://github.com/docker-library/redis/blob/5c8459f1bd20b7b7f92325f83898636f3c8db95f/7.0/Dockerfile)"
+  -	"[`7.0.12-alpine`, `7.0-alpine`, `7.0.12-alpine3.18`, `7.0-alpine3.18`](https://github.com/docker-library/redis/blob/5c8459f1bd20b7b7f92325f83898636f3c8db95f/7.0/alpine/Dockerfile)"
+  -	"[`6.2.13`, `6.2`, `6`, `6.2.13-bookworm`, `6.2-bookworm`, `6-bookworm`](https://github.com/docker-library/redis/blob/f2da8752a05b783eb805b67ad7a56a997a0fe91f/6.2/Dockerfile)"
+  -	"[`6.2.13-alpine`, `6.2-alpine`, `6-alpine`, `6.2.13-alpine3.18`, `6.2-alpine3.18`, `6-alpine3.18`](https://github.com/docker-library/redis/blob/f2da8752a05b783eb805b67ad7a56a997a0fe91f/6.2/alpine/Dockerfile)"
+  -	"[`6.0.20`, `6.0`, `6.0.20-bookworm`, `6.0-bookworm`](https://github.com/docker-library/redis/blob/873a7cac27da5a275d0c1e0c7d41724ae2701071/6.0/Dockerfile)"
+  -	"[`6.0.20-alpine`, `6.0-alpine`, `6.0.20-alpine3.18`, `6.0-alpine3.18`](https://github.com/docker-library/redis/blob/873a7cac27da5a275d0c1e0c7d41724ae2701071/6.0/alpine/Dockerfile)"
 input_registry:
   registry: docker.io
   account: library
 repo_sets:
   - redis:
-      input_base_tag: "7.0.*-bullseye"
+      input_base_tag: "6.0.*-alpine"
       output_repo: redis-official
   - redis:
-      input_base_tag: "6.2.*-bullseye"
+      input_base_tag: "6.0.*-bookworm"
+      output_repo: redis-official
+  - redis:
+      input_base_tag: "6.2.*-alpine"
+      output_repo: redis-official
+  - redis:
+      input_base_tag: "6.2.*-bookworm"
+      output_repo: redis-official
+  - redis:
+      input_base_tag: "7.0.*-alpine"
+      output_repo: redis-officia
+  - redis:
+      input_base_tag: "7.0.*-bookworm"
+      output_repo: redis-official
+  - redis:
+      input_base_tag: "7.2.*-alpine"
+      output_repo: redis-official
+  - redis:
+      input_base_tag: "7.2.*-bookworm"
       output_repo: redis-official
 runtimes:
   - type: docker_compose


### PR DESCRIPTION
- Redis/official: added bookworm and alpine support since bullseye versions are 2 months old.
- Redis/bitnami: updated tags
- Redis/ironbank: updates search tag