### PR TITLE
Updated bitnami search tags in image.yml

### DIFF
--- a/community_images/airflow/airflow/bitnami/image.yml
+++ b/community_images/airflow/airflow/bitnami/image.yml
@@ -27,11 +27,11 @@ input_registry:
   account: bitnami
 repo_sets:
   - airflow:
-      input_base_tag: "2.7.1-debian-11-r"
+      input_base_tag: "2.8.3-debian-12-r"
     airflow-scheduler:
-      input_base_tag: "2.7.1-debian-11-r"
+      input_base_tag: "2.8.3-debian-12-r"
     airflow-worker:
-      input_base_tag: "2.7.1-debian-11-r"
+      input_base_tag: "2.8.3-debian-12-r"
 runtimes:
   - type: k8s
     script: k8s_coverage.sh

--- a/community_images/apache/bitnami/image.yml
+++ b/community_images/apache/bitnami/image.yml
@@ -23,7 +23,7 @@ input_registry:
   account: bitnami
 repo_sets:
   - apache:
-      input_base_tag: "2.7.1-debian-11-r"
+      input_base_tag: "2.4.58-debian-12-r"
 runtimes:
   - type: k8s
     script: k8s_coverage.sh

--- a/community_images/couchdb/bitnami/image.yml
+++ b/community_images/couchdb/bitnami/image.yml
@@ -23,7 +23,7 @@ input_registry:
   account: bitnami
 repo_sets:
   - couchdb:
-      input_base_tag: "3.3.2-debian-11-r"
+      input_base_tag: "3.3.3-debian-12-r"
 runtimes:
   - type: docker_compose
     script: dc_coverage.sh

--- a/community_images/elasticsearch/bitnami/image.yml
+++ b/community_images/elasticsearch/bitnami/image.yml
@@ -23,9 +23,9 @@ input_registry:
   account: bitnami
 repo_sets:
   - elasticsearch:
-      input_base_tag: "8.10.3-debian-11-r"
+      input_base_tag: "7.17.18-debian-12-r"
   - elasticsearch:
-      input_base_tag: "7.17.14-debian-11-r"
+      input_base_tag: "8.12.2-debian-12-r"
 runtimes:
   - type: docker_compose
     script: dc_coverage.sh

--- a/community_images/envoy/bitnami/image.yml
+++ b/community_images/envoy/bitnami/image.yml
@@ -23,15 +23,15 @@ input_registry:
   account: bitnami
 repo_sets:
   - envoy:
-      input_base_tag: "1.29.0-debian-12-r"
-  - envoy:
-      input_base_tag: "1.28.0-debian-12-r"
-  - envoy:
-      input_base_tag: "1.27.2-debian-12-r"
-  - envoy:
-      input_base_tag: "1.26.6-debian-12-r"
-  - envoy:
       input_base_tag: "1.25.11-debian-12-r"
+  - envoy:
+      input_base_tag: "1.26.7-debian-12-r"
+  - envoy:
+      input_base_tag: "1.27.3-debian-12-r"
+  - envoy:
+      input_base_tag: "1.28.1-debian-12-r"
+  - envoy:
+      input_base_tag: "1.29.2-debian-12-r"
 runtimes:
   - type: docker_compose
     script: dc_coverage.sh

--- a/community_images/etcd/bitnami/image.yml
+++ b/community_images/etcd/bitnami/image.yml
@@ -25,9 +25,9 @@ input_registry:
   account: bitnami
 repo_sets:
   - etcd:
-      input_base_tag: "3.5.9-debian-11-r"
+      input_base_tag: "3.4.30-debian-12-r"
   - etcd:
-      input_base_tag: "3.4.27-debian-11-r"
+      input_base_tag: "3.5.12-debian-12-r"
 runtimes:
   - type: k8s
     script: k8s_coverage.sh

--- a/community_images/fluent-bit/bitnami/image.yml
+++ b/community_images/fluent-bit/bitnami/image.yml
@@ -22,7 +22,7 @@ input_registry:
   account: bitnami
 repo_sets:
   - fluent-bit:
-      input_base_tag: "2.2."
+      input_base_tag: "2.2.2-debian-12-r"
 runtimes:
   - type: docker_compose
     script: dc_coverage.sh

--- a/community_images/fluentd/bitnami/image.yml
+++ b/community_images/fluentd/bitnami/image.yml
@@ -23,7 +23,7 @@ input_registry:
   account: bitnami
 repo_sets:
   - fluentd:
-      input_base_tag: "1.16.2-debian-11-r"
+      input_base_tag: "1.16.3-debian-12-r"
 runtimes:
   - type: k8s
     script: k8s_coverage.sh

--- a/community_images/ghost/bitnami/image.yml
+++ b/community_images/ghost/bitnami/image.yml
@@ -23,7 +23,7 @@ input_registry:
   account: bitnami
 repo_sets:
   - ghost:
-      input_base_tag: "5.69.0-debian-11-r"
+      input_base_tag: "5.80.2-debian-12-r"
 runtimes:
   - type: k8s
     script: k8s_coverage.sh

--- a/community_images/haproxy/bitnami/image.yml
+++ b/community_images/haproxy/bitnami/image.yml
@@ -23,7 +23,7 @@ input_registry:
   account: bitnami
 repo_sets:
   - haproxy:
-      input_base_tag: "2.8.3-debian-11-r"
+      input_base_tag: "2.9.6-debian-12-r"
 runtimes:
   - type: k8s
     script: k8s_coverage.sh

--- a/community_images/influxdb/bitnami/image.yml
+++ b/community_images/influxdb/bitnami/image.yml
@@ -23,7 +23,7 @@ input_registry:
   account: bitnami
 repo_sets:
   - influxdb:
-      input_base_tag: "2.7.1-debian-11-r"
+      input_base_tag: "2.7.5-debian-12-r"
 runtimes:
   - type: k8s
     script: k8s_coverage.sh

--- a/community_images/mariadb/bitnami/image.yml
+++ b/community_images/mariadb/bitnami/image.yml
@@ -23,19 +23,19 @@ input_registry:
   account: bitnami
 repo_sets:
   - mariadb:
-      input_base_tag: "11.1.2-debian-11-r"
+      input_base_tag: "10.4.33-debian-12-r"
   - mariadb:
-      input_base_tag: "11.0.3-debian-11-r"
+      input_base_tag: "10.5.24-debian-12-r"
   - mariadb:
-      input_base_tag: "10.11.5-debian-11-r"
+      input_base_tag: "10.6.17-debian-12-r"
   - mariadb:
-      input_base_tag: "10.10.6-debian-11-r"
+      input_base_tag: "10.11.7-debian-12-r"
   - mariadb:
-      input_base_tag: "10.6.15-debian-11-r"
+      input_base_tag: "11.0.5-debian-12-r"
   - mariadb:
-      input_base_tag: "10.5.22-debian-11-r"
+      input_base_tag: "11.1.4-debian-12-r"
   - mariadb:
-      input_base_tag: "10.4.31-debian-11-r"
+      input_base_tag: "11.2.3-debian-12-r"
 runtimes:
   - type: k8s
     script: k8s_coverage.sh

--- a/community_images/memcached/bitnami/image.yml
+++ b/community_images/memcached/bitnami/image.yml
@@ -24,7 +24,7 @@ input_registry:
   account: bitnami
 repo_sets:
   - memcached:
-      input_base_tag: "1.6.21-debian-11-r"
+      input_base_tag: "1.6.24-debian-12-r"
 runtimes:
   - type: k8s
     helm:

--- a/community_images/mongodb/bitnami/image.yml
+++ b/community_images/mongodb/bitnami/image.yml
@@ -23,11 +23,7 @@ input_registry:
   account: bitnami
 repo_sets:
   - mongodb:
-      input_base_tag: "7.0.2-debian-11-r"
-  - mongodb:
-      input_base_tag: "6.0.11-debian-11-r"
-  - mongodb:
-      input_base_tag: "5.0.21-debian-11-r"
+      input_base_tag: "7.0.6-debian-12-r"
 runtimes:
   - type: k8s
     script: k8s_coverage.sh

--- a/community_images/mysql/bitnami/image.yml
+++ b/community_images/mysql/bitnami/image.yml
@@ -23,11 +23,9 @@ input_registry:
   account: bitnami
 repo_sets:
   - mysql:
-      input_base_tag: "8.1.0-debian-11-r"
+      input_base_tag: "8.3.0-debian-12-r"
   - mysql:
-      input_base_tag: "8.0.34-debian-11-r"
-  - mysql:
-      input_base_tag: "5.7.43-debian-11-r"
+      input_base_tag: "8.0.36-debian-12-r"
 runtimes:
   - type: k8s
     script: k8s_coverage.sh

--- a/community_images/nats/bitnami/image.yml
+++ b/community_images/nats/bitnami/image.yml
@@ -23,7 +23,7 @@ input_registry:
   account: bitnami
 repo_sets:
   - nats:
-      input_base_tag: "2.10.2-debian-11-r"
+      input_base_tag: "2.10.12-debian-12-r"
 runtimes:
   - type: k8s
     script: k8s_coverage.sh

--- a/community_images/nginx/bitnami/image.yml
+++ b/community_images/nginx/bitnami/image.yml
@@ -23,9 +23,9 @@ input_registry:
   account: bitnami
 repo_sets:
   - nginx:
-      input_base_tag: "1.25.2-debian-11-r"
+      input_base_tag: "1.24.0-debian-12-r"
   - nginx:
-      input_base_tag: "1.24.0-debian-11-r"
+      input_base_tag: "1.25.4-debian-12-r"
 runtimes:
   - type: k8s
     script: k8s_coverage.sh

--- a/community_images/node-exporter/bitnami/image.yml
+++ b/community_images/node-exporter/bitnami/image.yml
@@ -22,7 +22,7 @@ input_registry:
   account: bitnami
 repo_sets:
   - node-exporter:
-      input_base_tag: "1.7.0-debian-11-r"
+      input_base_tag: "1.7.0-debian-12-r"
 runtimes:
   - type: docker_compose
     script: dc_coverage.sh

--- a/community_images/postgresql/bitnami/image.yml
+++ b/community_images/postgresql/bitnami/image.yml
@@ -23,17 +23,15 @@ input_registry:
   account: bitnami
 repo_sets:
   - postgresql:
-      input_base_tag: "16.0.0-debian-11-r"
+      input_base_tag: "12.18.0-debian-12-r"
   - postgresql:
-      input_base_tag: "15.4.0-debian-11-r"
+      input_base_tag: "13.14.0-debian-12-r"
   - postgresql:
-      input_base_tag: "14.9.0-debian-11-r"
+      input_base_tag: "14.11.0-debian-12-r"
   - postgresql:
-      input_base_tag: "13.12.0-debian-11-r"
+      input_base_tag: "15.6.0-debian-12-r"
   - postgresql:
-      input_base_tag: "12.16.0-debian-11-r"
-  - postgresql:
-      input_base_tag: "11.21.0-debian-11-r"
+      input_base_tag: "16.2.0-debian-12-r"
 runtimes:
   - type: k8s
     script: k8s_coverage.sh

--- a/community_images/prometheus/bitnami/image.yml
+++ b/community_images/prometheus/bitnami/image.yml
@@ -23,7 +23,7 @@ input_registry:
   account: bitnami
 repo_sets:
   - prometheus:
-      input_base_tag: "2.47.1-debian-11-r"
+      input_base_tag: "2.50.1-debian-12-r"
 runtimes:
   - type: k8s
     script: k8s_coverage.sh

--- a/community_images/rabbitmq/bitnami/image.yml
+++ b/community_images/rabbitmq/bitnami/image.yml
@@ -23,11 +23,11 @@ input_registry:
   account: bitnami
 repo_sets:
   - rabbitmq:
-      input_base_tag: "3.12.6-debian-11-r"
+      input_base_tag: "3.10.25-debian-12-r"
   - rabbitmq:
-      input_base_tag: "3.11.23-debian-11-r"
+      input_base_tag: "3.11.28-debian-12-r"
   - rabbitmq:
-      input_base_tag: "3.10.25-debian-11-r"
+      input_base_tag: "3.12.13-debian-12-r"
 runtimes:
   - type: k8s
     script: k8s_coverage.sh

--- a/community_images/redis-cluster/bitnami/image.yml
+++ b/community_images/redis-cluster/bitnami/image.yml
@@ -25,9 +25,9 @@ input_registry:
   account: bitnami
 repo_sets:
   - redis-cluster:
-      input_base_tag: "7.2.1-debian-11-r"
+      input_base_tag: "7.0.15-debian-12-r"
   - redis-cluster:
-      input_base_tag: "7.0.13-debian-11-r"
+      input_base_tag: "7.2.4-debian-12-r"
 runtimes:
   - type: k8s
     helm:

--- a/community_images/redis/bitnami/image.yml
+++ b/community_images/redis/bitnami/image.yml
@@ -23,11 +23,11 @@ input_registry:
   account: bitnami
 repo_sets:
   - redis:
-      input_base_tag: "7.2.4-debian-12-r"
+      input_base_tag: "6.2.14-debian-12-r"
   - redis:
       input_base_tag: "7.0.15-debian-12-r"
   - redis:
-      input_base_tag: "6.2.14-debian-12-r"
+      input_base_tag: "7.2.4-debian-12-r"
 runtimes:
   - type: k8s
     script: k8s_coverage.sh

--- a/community_images/telegraf/bitnami/image.yml
+++ b/community_images/telegraf/bitnami/image.yml
@@ -23,7 +23,7 @@ input_registry:
   account: bitnami
 repo_sets:
   - telegraf:
-      input_base_tag: "1.28.2-debian-11-r"
+      input_base_tag: "1.30.0-debian-12-r"
 runtimes:
   - type: docker_compose
     script: dc_coverage.sh

--- a/community_images/wordpress/bitnami/image.yml
+++ b/community_images/wordpress/bitnami/image.yml
@@ -23,7 +23,7 @@ input_registry:
   account: bitnami
 repo_sets:
   - wordpress:
-      input_base_tag: "6.3.1-debian-11-r"
+      input_base_tag: "6.4.3-debian-12-r"
 runtimes:
   - type: k8s
     script: k8s_coverage.sh

--- a/community_images/zookeeper/bitnami/image.yml
+++ b/community_images/zookeeper/bitnami/image.yml
@@ -23,11 +23,9 @@ input_registry:
   account: bitnami
 repo_sets:
   - zookeeper:
-      input_base_tag: "3.9.1-debian-11-r"
+      input_base_tag: "3.8.4-debian-12-r"
   - zookeeper:
-      input_base_tag: "3.8.2-debian-11-r"
-  - zookeeper:
-      input_base_tag: "3.7.2-debian-11-r"
+      input_base_tag: "3.9.2-debian-12-r"
 runtimes:
   - type: k8s
     script: k8s_coverage.sh


### PR DESCRIPTION
Updated base search tags for bitnami images:
- `airflow/airflow/bitnami`
- `apache/bitnami`
- `consul/bitnami`
- `couched/bitnami`
- `elastic search/bitnami`
- `envoy/bitnami`
- `etcd/bitnami`
- `fluent-bit/bitnami`
-  `fluentd/bitnami`
- `ghost/bitnami`
- `haproxy/bitnami`
- `influxes/bitnami`
- `mariadb/bitnami`
- `memcached/bitnami`
- `mongoldb/bitnami`
- `mysql/bitnami`
- `nats/bitnami`
- `nginx/bitnami`
- `node-exporter/bitnami`
- `postgresql/bitnami`
- `prometheus/bitnami`
- `rabbitmq/bitnami`
- `redis/bitnami`
- `redis-cluster/bitnami`
- `telegraf/bitnami`
- `wordpress/bitnami`
- `zookeeper/bitnami`