### PR TITLE
Added before script config

### DIFF
--- a/community_images/common/orchestrator/coverage_runner.py
+++ b/community_images/common/orchestrator/coverage_runner.py
@@ -92,7 +92,7 @@ class CoverageRunner:
                     "image_tag_details": image_tag_details,
                     "runtime_props": runtime_props,
                     "image_script_dir": image_script_dir,
-                }));
+                }))
 
                 if os.path.exists(before_script_path):
                     Utils.run_cmd([before_script_path, json_file_path])

--- a/community_images/common/orchestrator/coverage_runner.py
+++ b/community_images/common/orchestrator/coverage_runner.py
@@ -75,7 +75,28 @@ class CoverageRunner:
             runtime_runner = runtime_runner_map[runtime_type]
 
             script = runtime_props.get("script")
+            before_script = runtime_props.get("before_script")
+
             script_path = None
+            before_script_path = None
+
+            if before_script:
+                logging.info(
+                    f"Running before runtime script for {runtime_type}: {before_script}")
+                before_script_path = os.path.join(image_script_dir, before_script)
+                logging.info(f"Before script abs path to execute: {before_script_path}")
+
+                json_file_path = self._dump_runner_to_json( image_script_dir, dict({
+                    "namespace_name": namespace_name,
+                    "release_name": release_name,
+                    "image_tag_details": image_tag_details,
+                    "runtime_props": runtime_props,
+                    "image_script_dir": image_script_dir,
+                }));
+
+                if os.path.exists(before_script_path):
+                    Utils.run_cmd([before_script_path, json_file_path])
+
             if script:
                 logging.info(
                     f"Running runtime script for {runtime_type}: {script}")


### PR DESCRIPTION
## What is?
This PR adds config to run a script before raising pod/container/helm-chart.

## How it runs?
1. Before/Setup scripts runs.
2. Runtime deployed
3. Coverage script runs

## Usage:
**Image.yml**
```yaml
...
runtimes:
 - type: <type_of_runtime>
   before_script: setup_script.sh
   ...
...
```
Sample setup_script.sh (use the name `docker_before.sh`, `dc_before.sh`, `k8s_before.sh` for convention)
```sh
set -x
set -e

JSON_PARAMS="$1"

JSON=$(cat "$JSON_PARAMS")

echo "Json params for docker compose coverage = $JSON"

# shellcheck disable=SC1091
SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"

# Your script here
#  Read json params as done in coverage script except '.command' key(It was not found to be json serialisable so dropped).
```
