### PR TITLE
Nginx - Added etc/ssl/certs to rfignore

### DIFF
--- a/community_images/nginx/bitnami/.rfignore
+++ b/community_images/nginx/bitnami/.rfignore
@@ -4,3 +4,4 @@ opt/bitnami/common/licenses
 opt/bitnami/licenses
 opt/bitnami/nginx/licenses
 usr/share/common-licenses
+etc/ssl/certs

--- a/community_images/nginx/bitnami/.rfignore
+++ b/community_images/nginx/bitnami/.rfignore
@@ -4,4 +4,4 @@ opt/bitnami/common/licenses
 opt/bitnami/licenses
 opt/bitnami/nginx/licenses
 usr/share/common-licenses
-etc/ssl/certs
+etc/ssl

--- a/community_images/nginx/ironbank/.rfignore
+++ b/community_images/nginx/ironbank/.rfignore
@@ -5,4 +5,3 @@ etc/ssl/certs
 usr/lib/systemd/system/nginx*
 usr/lib64/nginx/modules
 usr/share/licenses
-

--- a/community_images/nginx/ironbank/.rfignore
+++ b/community_images/nginx/ironbank/.rfignore
@@ -1,6 +1,8 @@
 usr/share/nginx
 usr/libexec/initscripts/legacy-actions/nginx
 etc/nginx
+etc/ssl/certs
 usr/lib/systemd/system/nginx*
 usr/lib64/nginx/modules
 usr/share/licenses
+

--- a/community_images/nginx/ironbank/.rfignore
+++ b/community_images/nginx/ironbank/.rfignore
@@ -1,7 +1,7 @@
 usr/share/nginx
 usr/libexec/initscripts/legacy-actions/nginx
 etc/nginx
-etc/ssl/certs
+etc/ssl
 usr/lib/systemd/system/nginx*
 usr/lib64/nginx/modules
 usr/share/licenses

--- a/community_images/nginx/official/.rfignore
+++ b/community_images/nginx/official/.rfignore
@@ -1,1 +1,2 @@
 usr/share/common-licenses
+etc/ssl/certs

--- a/community_images/nginx/official/.rfignore
+++ b/community_images/nginx/official/.rfignore
@@ -1,2 +1,2 @@
 usr/share/common-licenses
-etc/ssl/certs
+etc/ssl


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Rapidfort might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
Added `/etc/ssl/certs` for all `.rfignore` of all nginx images.