### PR TITLE
adding requests to be specific to 2.31.0

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -87,4 +87,5 @@ minikube addons enable ingress
 
 # add common python modules
 pip install --upgrade pip
+pip install requests==2.31.0
 pip install backoff python-dateutil ruamel.yaml docker


### PR DESCRIPTION
fixes the issue - urllib3.exceptions.URLSchemeUnknown: Not supported URL scheme http+docker

ref: https://github.com/docker/docker-py/issues/3256