### PR TITLE
Fix Vault-IB build failure

### DIFF
--- a/community_images/vault/ironbank/image.yml
+++ b/community_images/vault/ironbank/image.yml
@@ -20,7 +20,7 @@ input_registry:
   account: ironbank
 repo_sets:
   - hashicorp/vault:
-      input_base_tag: "9.1."
+      input_base_tag: "1.17."
       output_repo: vault-ib
 runtimes:
   - type: docker_compose

--- a/ironbank_tags.yml
+++ b/ironbank_tags.yml
@@ -241,9 +241,9 @@ traefik-ib:
 vault-k8s-ib:
   search_tags:
     - v1.4.
-vault-ib:
-  search_tags:
-    - 9.1.
+# vault-ib:
+#   search_tags:
+#     - 9.1.
 vcluster-ib:
   search_tags:
     - 0.19.


### PR DESCRIPTION
Fixing Vault-IB build failure due to an incorrect tag in the manifest. 

- Manually updated the correct tag in image.yml
- Commented out Vault-IB from ironbank_tags.yml 