### PR TITLE
Implemented haproxy-latest with checker for version

### DIFF
--- a/community_images/haproxy-latest/ironbank/dc_coverage.sh
+++ b/community_images/haproxy-latest/ironbank/dc_coverage.sh
@@ -14,21 +14,24 @@ JSON=$(cat "$JSON_PARAMS")
 
 echo "Json params for docker compose coverage = $JSON"
 
+# Parse version from JSON or environment variable
+VERSION=$(jq -r '.version' <<< "$JSON")
+# If the version is not in JSON, you can alternatively set it as an environment variable
+# VERSION="${HAPROXY_IMAGE_TAG}"
+
 # roundrobin mode
 CONTAINER1_NAME=haproxy-1
 # leastconn mode
 CONTAINER2_NAME=haproxy-2
 # source mode
 CONTAINER3_NAME=haproxy-3
-# quic protocol tests
+# quic protocol tests (only for version 3.0+)
 CONTAINER4_NAME=haproxy-quic
 
 # log for debugging
 docker inspect "${CONTAINER1_NAME}"
 docker inspect "${CONTAINER2_NAME}"
 docker inspect "${CONTAINER3_NAME}"
-docker inspect "${CONTAINER4_NAME}"
-
 
 # finding ports
 docker inspect "${CONTAINER1_NAME}" | jq -r ".[].NetworkSettings.Ports.\"80/tcp\"[0].HostPort"
@@ -37,27 +40,21 @@ docker inspect "${CONTAINER2_NAME}" | jq -r ".[].NetworkSettings.Ports.\"80/tcp\
 PORT2=$(docker inspect "${CONTAINER2_NAME}" | jq -r ".[].NetworkSettings.Ports.\"80/tcp\"[0].HostPort")
 docker inspect "${CONTAINER3_NAME}" | jq -r ".[].NetworkSettings.Ports.\"80/tcp\"[0].HostPort"
 PORT3=$(docker inspect "${CONTAINER3_NAME}" | jq -r ".[].NetworkSettings.Ports.\"80/tcp\"[0].HostPort")
-docker inspect "${CONTAINER4_NAME}" | jq -r ".[].NetworkSettings.Ports.\"443/tcp\"[0].HostPort"
-PORT4=$(docker inspect "${CONTAINER4_NAME}" | jq -r ".[].NetworkSettings.Ports.\"443/tcp\"[0].HostPort")
-
 
 # run curl in loop (roundrobin)
-for i in {1..10};
-do 
+for i in {1..10}; do 
     echo "Attempt $i"
     curl http://localhost:"${PORT1}"
 done
 
 # run curl in loop for app1 route
-for i in {1..10};
-do 
+for i in {1..10}; do 
     echo "Attempt $i"
     curl http://localhost:"${PORT1}"/app1
 done
 
 # run curl in loop for app2 route
-for i in {1..10};
-do 
+for i in {1..10}; do 
     echo "Attempt $i"
     curl http://localhost:"${PORT1}"/app2
 done
@@ -66,21 +63,26 @@ done
 curl http://localhost:"${PORT1}"/admin
 
 # run curl in loop (leastconn)
-for i in {1..10};
-do 
+for i in {1..10}; do 
     echo "Attempt $i"
     curl http://localhost:"${PORT2}"
 done
 
 # run curl in loop (source)
-for i in {1..10};
-do 
+for i in {1..10}; do 
     echo "Attempt $i"
     curl http://localhost:"${PORT3}"
 done
 
-# QUIC Testing
-for i in {1..10}; do
-    echo "HTTP/2 Attempt $i"
-    curl --http2 -k https://localhost:"${PORT_QUIC}"
-done
+# Additional tests for version 3.0+
+if [[ "$VERSION" =~ ^3 ]]; then
+    docker inspect "${CONTAINER4_NAME}"
+    docker inspect "${CONTAINER4_NAME}" | jq -r ".[].NetworkSettings.Ports.\"443/tcp\"[0].HostPort"
+    PORT4=$(docker inspect "${CONTAINER4_NAME}" | jq -r ".[].NetworkSettings.Ports.\"443/tcp\"[0].HostPort")
+
+    # QUIC Testing
+    for i in {1..10}; do
+        echo "HTTP/2 Attempt $i"
+        curl --http2 -k https://localhost:"${PORT4}"
+    done
+fi

--- a/community_images/haproxy-latest/ironbank/dc_coverage_tcp.sh
+++ b/community_images/haproxy-latest/ironbank/dc_coverage_tcp.sh
@@ -49,14 +49,14 @@ for i in {1..5}; do
     curl http://localhost:"${PORT3}"
 done
 
-# Test dynamic SSL certificate updates
-printf "set ssl cert /etc/ssl/private/haproxy.pem <<\n$(cat /path/to/new/cert.pem)\n" | socat stdio /var/run/haproxy.sock
-printf "commit ssl cert /etc/ssl/private/haproxy.pem" | socat stdio /var/run/haproxy.sock
+# Additional tests for version 3.0+
+if [[ "$VERSION" =~ ^3 ]]; then
+    # Test dynamic SSL certificate updates
+    new_cert=$(cat /path/to/new/cert.pem)
+    printf "set ssl cert /etc/ssl/private/haproxy.pem <<\n%s\n" "$new_cert" | socat stdio /var/run/haproxy.sock
+    printf "commit ssl cert /etc/ssl/private/haproxy.pem\n" | socat stdio /var/run/haproxy.sock
 
-# Test dynamic server weight adjustment
-printf "set server be_servers/server1 weight 20" | socat stdio /var/run/haproxy.sock
-printf "set server be_servers/server2 weight 5" | socat stdio /var/run/haproxy.sock
-
-# Observability Testing (Metrics)
-echo "Fetching metrics"
-curl http://localhost:8404/metrics
+    # Test dynamic server weight adjustment
+    printf "set server be_servers/server1 weight 20\n" | socat stdio /var/run/haproxy.sock
+    printf "set server be_servers/server2 weight 5\n" | socat stdio /var/run/haproxy.sock
+fi

--- a/community_images/haproxy-latest/ironbank/dc_coverage_tcp.sh
+++ b/community_images/haproxy-latest/ironbank/dc_coverage_tcp.sh
@@ -21,48 +21,42 @@ CONTAINER2_NAME=haproxy-2
 # deflate mode
 CONTAINER3_NAME=haproxy-3
 
-
 # log for debugging
 docker inspect "${CONTAINER1_NAME}"
 docker inspect "${CONTAINER2_NAME}"
 docker inspect "${CONTAINER3_NAME}"
 
 # finding ports
-docker inspect "${CONTAINER1_NAME}" | jq -r ".[].NetworkSettings.Ports.\"80/tcp\"[0].HostPort"
 PORT1=$(docker inspect "${CONTAINER1_NAME}" | jq -r ".[].NetworkSettings.Ports.\"80/tcp\"[0].HostPort")
-docker inspect "${CONTAINER2_NAME}" | jq -r ".[].NetworkSettings.Ports.\"80/tcp\"[0].HostPort"
 PORT2=$(docker inspect "${CONTAINER2_NAME}" | jq -r ".[].NetworkSettings.Ports.\"80/tcp\"[0].HostPort")
-docker inspect "${CONTAINER3_NAME}" | jq -r ".[].NetworkSettings.Ports.\"80/tcp\"[0].HostPort"
 PORT3=$(docker inspect "${CONTAINER3_NAME}" | jq -r ".[].NetworkSettings.Ports.\"80/tcp\"[0].HostPort")
 
 # run curl in loop (identity)
-for i in {1..5};
-do 
+for i in {1..5}; do 
     echo "Attempt $i"
     curl http://localhost:"${PORT1}"
 done
 
 # run curl in loop (gzip)
-for i in {1..5};
-do 
+for i in {1..5}; do 
     echo "Attempt $i"
     curl http://localhost:"${PORT2}"
 done
 
 # run curl in loop (deflate)
-for i in {1..5};
-do 
+for i in {1..5}; do 
     echo "Attempt $i"
     curl http://localhost:"${PORT3}"
 done
 
-# Additional tests for version 3.0+
-if [[ "$VERSION" =~ ^3 ]]; then
-    # Test dynamic SSL certificate updates
-    echo 'set ssl cert /etc/ssl/private/haproxy.pem <<\n$(cat /path/to/new/cert.pem)\n' | socat stdio /var/run/haproxy.sock
-    echo 'commit ssl cert /etc/ssl/private/haproxy.pem' | socat stdio /var/run/haproxy.sock
+# Test dynamic SSL certificate updates
+printf "set ssl cert /etc/ssl/private/haproxy.pem <<\n$(cat /path/to/new/cert.pem)\n" | socat stdio /var/run/haproxy.sock
+printf "commit ssl cert /etc/ssl/private/haproxy.pem" | socat stdio /var/run/haproxy.sock
 
-    # Test dynamic server weight adjustment
-    echo "set server be_servers/server1 weight 20" | socat stdio /var/run/haproxy.sock
-    echo "set server be_servers/server2 weight 5" | socat stdio /var/run/haproxy.sock
-fi
+# Test dynamic server weight adjustment
+printf "set server be_servers/server1 weight 20" | socat stdio /var/run/haproxy.sock
+printf "set server be_servers/server2 weight 5" | socat stdio /var/run/haproxy.sock
+
+# Observability Testing (Metrics)
+echo "Fetching metrics"
+curl http://localhost:8404/metrics

--- a/community_images/haproxy-latest/ironbank/dc_coverage_tcp.sh
+++ b/community_images/haproxy-latest/ironbank/dc_coverage_tcp.sh
@@ -55,3 +55,14 @@ do
     echo "Attempt $i"
     curl http://localhost:"${PORT3}"
 done
+
+# Additional tests for version 3.0+
+if [[ "$VERSION" =~ ^3 ]]; then
+    # Test dynamic SSL certificate updates
+    echo 'set ssl cert /etc/ssl/private/haproxy.pem <<\n$(cat /path/to/new/cert.pem)\n' | socat stdio /var/run/haproxy.sock
+    echo 'commit ssl cert /etc/ssl/private/haproxy.pem' | socat stdio /var/run/haproxy.sock
+
+    # Test dynamic server weight adjustment
+    echo "set server be_servers/server1 weight 20" | socat stdio /var/run/haproxy.sock
+    echo "set server be_servers/server2 weight 5" | socat stdio /var/run/haproxy.sock
+fi


### PR DESCRIPTION
Used a separate folder for HAProxy latest version with logic to differentiate tests for versions < 3.0 and the latest versions. No implementation of http3 because it is experimental. 

Major updates in HAProxy 3.0: Usage of QUIC protocol, dynamic SSL certificate updates, and dynamic server weight adjustment
