### PR TITLE
Fix vault-ib failing pipeline

### DIFF
--- a/community_images/vault/ironbank/image.yml
+++ b/community_images/vault/ironbank/image.yml
@@ -2,13 +2,13 @@ name: vault-ib
 official_name: Vault Iron Bank
 official_website: https://www.vaultproject.io/
 source_image_provider: Platform One
-source_image_repo: registry1.dso.mil/ironbank/hashicorp/vault/1.14
-source_image_repo_link: https://registry1.dso.mil/harbor/projects/3/repositories/hashicorp%2Fvault%2F1.14
-source_image_readme: https://repo1.dso.mil/dsop/hashicorp/vault/1.14/-/blob/development/README.md
+source_image_repo: registry1.dso.mil/ironbank/hashicorp/vault/1.15
+source_image_repo_link: https://registry1.dso.mil/harbor/projects/3/repositories/hashicorp%2Fvault%2F1.15
+source_image_readme: https://repo1.dso.mil/dsop/hashicorp/vault/1.15/-/blob/development/README.md
 rf_docker_link: rapidfort/vault-ib
 image_workflow_name: vault_ironbank
 github_location: vault/ironbank
-report_url: https://us01.rapidfort.com/app/community/imageinfo/registry1.dso.mil%2Fironbank%2Fhashicorp%2Fvault%2F1.14
+report_url: https://us01.rapidfort.com/app/community/imageinfo/registry1.dso.mil%2Fironbank%2Fhashicorp%2Fvault%2F1.15
 usage_instructions: |
   $ docker run --cap-add=IPC_LOCK -e 'VAULT_DEV_ROOT_TOKEN_ID=myroot' -e 'VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:1234' rapidfort/vault-ib
 what_is_text: |
@@ -20,7 +20,7 @@ input_registry:
   account: ironbank
 repo_sets:
   - hashicorp/vault:
-      input_base_tag: "9.1."
+      input_base_tag: "1.15."
       output_repo: vault-ib
 runtimes:
   - type: docker_compose


### PR DESCRIPTION
Fix vault-ib failing pipeline: https://github.com/rapidfort/community-images/actions/runs/10037302352/job/27736860238

1.14 repository is archived, updated the image.yml to use 1.15