### PR TITLE
Added sleep in thanos-ib k8s_coverage to make it more robust

### DIFF
--- a/community_images/thanos/ironbank/k8s_coverage.sh
+++ b/community_images/thanos/ironbank/k8s_coverage.sh
@@ -13,6 +13,8 @@ echo "Json params for k8s coverage = $JSON"
 SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 NAMESPACE=$(jq -r '.namespace_name' < "$JSON_PARAMS")
 
+sleep 30
+
 # adding cleanup trap for prometheus helm release
 # beyond this point, if THIS script exits, with whichever exit code and due to whatever reason, the cleanup script will be executed
 trap '${SCRIPTPATH}/cleanup_script_for_prometheus_helm_release.sh ${NAMESPACE}' EXIT


### PR DESCRIPTION
Build for thanos-ib tends to fail randomly sometimes. While everything is technically fine, the error seems incidental. In an effort to make the coverage more robust, sleep of 30 seconds has been added before k8s_coverage to make sure that all the pods and services from both the charts are set up properly before coverage is executed.