### PR TITLE
Use 1.15 as Vault-IB tag 

### DIFF
--- a/community_images/vault/ironbank/image.yml
+++ b/community_images/vault/ironbank/image.yml
@@ -20,7 +20,7 @@ input_registry:
   account: ironbank
 repo_sets:
   - hashicorp/vault:
-      input_base_tag: "9.1."
+      input_base_tag: "1.15."
       output_repo: vault-ib
 runtimes:
   - type: docker_compose

--- a/scripts/prepare_ironbank_tags.sh
+++ b/scripts/prepare_ironbank_tags.sh
@@ -15,7 +15,7 @@ IMAGE_TEMP_LST=${ROOT_PATH}/image.temp.lst
 # There is an issue from ironbank side regarding the vault image. Ironbank has incorrectly marked the latest vault image version as "9.1" instead of "1.7".
 # Our automated scripts pull information from ironbank and get the incorrect tag. 
 # Until the issue from ironbank is fixed we are excluding vault/ironbank for any automation script.
-sort "${IMAGE_LST}" | grep ironbank | grep -v vault/ironbank > "${IMAGE_TEMP_LST}"
+sort "${IMAGE_LST}" | grep ironbank > "${IMAGE_TEMP_LST}"
 
 REPO_SET_FILE=${ROOT_PATH}/ironbank_tags.yml
 echo "" > "${REPO_SET_FILE}"


### PR DESCRIPTION
- Changed the tag to 1.15
- 1.17 is having problems getting pulled from registry. Possibly because of wrong tag in hardening manifest.
