### PR TITLE
Set readOnlyRootFilesystem to false in overrides of k8s runtime

### DIFF
--- a/community_images/apache/bitnami/overrides.yml
+++ b/community_images/apache/bitnami/overrides.yml
@@ -5,6 +5,7 @@ containerSecurityContext:
   enabled: true
   runAsUser: 1001
   allowPrivilegeEscalation: true
+  readOnlyRootFilesystem: false
   capabilities:
     add: ["SYS_PTRACE"]
 extraEnvVars:


### PR DESCRIPTION
Fixed the RF_RW_DIR env var issue by setting readOnlyRootFilesystem to false in overrides.yml for k8s runtime