### PR TITLE
Set readOnlyRootFilesystem to false in overrides.yml for k8s runtime for mongodb

### DIFF
--- a/community_images/mongodb/bitnami/overrides.yml
+++ b/community_images/mongodb/bitnami/overrides.yml
@@ -5,6 +5,7 @@ containerSecurityContext:
   enabled: true
   runAsUser: 1001
   allowPrivilegeEscalation: true
+  readOnlyRootFilesystem: false
   capabilities:
     add: ["SYS_PTRACE"]
 extraEnvVars:
@@ -15,6 +16,7 @@ arbiter:
     enabled: true
     runAsUser: 1001
     allowPrivilegeEscalation: true
+    readOnlyRootFilesystem: false
     capabilities:
       add: ["SYS_PTRACE"]
   extraEnvVars:
@@ -25,6 +27,7 @@ hidden:
     enabled: true
     runAsUser: 1001
     allowPrivilegeEscalation: true
+    readOnlyRootFilesystem: false
     capabilities:
       add: ["SYS_PTRACE"]
   extraEnvVars:


### PR DESCRIPTION
Fixed the RF_RW_DIR env var issue by setting readOnlyRootFilesystem to false in overrides.yml for k8s runtime